### PR TITLE
Leifa

### DIFF
--- a/networkmanager.cpp
+++ b/networkmanager.cpp
@@ -77,7 +77,7 @@ void NetworkManager::ship_server_packet(QString p_packet)
 void NetworkManager::handle_ms_packet()
 {
   char buffer[buffer_max_size];
-  std::memset(buffer, 0, sizeof(buffer));
+  std::memset(buffer, 0, buffer_max_size);
   ms_socket->read(buffer, buffer_max_size);
 
   QString in_data = buffer;
@@ -216,7 +216,7 @@ void NetworkManager::retry_ms_connect()
 void NetworkManager::handle_server_packet()
 {
   char buffer[buffer_max_size];
-  std::memset(buffer, 0, sizeof(buffer));
+  std::memset(buffer, 0, buffer_max_size);
   server_socket->read(buffer, buffer_max_size);
 
   QString in_data = buffer;

--- a/networkmanager.cpp
+++ b/networkmanager.cpp
@@ -78,7 +78,7 @@ void NetworkManager::handle_ms_packet()
 {
   char buffer[buffer_max_size];
   std::memset(buffer, 0, sizeof(buffer));
-  server_socket->read(buffer, buffer_max_size);
+  ms_socket->read(buffer, buffer_max_size);
 
   QString in_data = buffer;
 


### PR DESCRIPTION
Fix a major oversight: the previous update would disable master server code handling but also potentially split data received in two.